### PR TITLE
Fix lock acquisition in SQLite accessor

### DIFF
--- a/src/sqlite/AbstractSqliteAccessor.ts
+++ b/src/sqlite/AbstractSqliteAccessor.ts
@@ -40,7 +40,7 @@ export abstract class AbstractSqliteAccessor {
 			return;
 
 		try {
-			this.#initLocker.acquire();
+			await this.#initLocker.acquire();
 			if (this.#initialized)
 				return;
 


### PR DESCRIPTION
## Summary
- await lock acquisition to ensure asynchronous initialization
- fix indentation on lock acquisition block

## Testing
- `npm test` *(fails: Cannot find module 'better-sqlite3')*
- `npm run lint` *(fails: Cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_685ac174d2c88324a7ef49e90568e6dc