### PR TITLE
fix: Proper milliseconds calculation for Event Locker

### DIFF
--- a/src/sqlite/SqliteEventLocker.ts
+++ b/src/sqlite/SqliteEventLocker.ts
@@ -81,16 +81,16 @@ export class SqliteEventLocker extends AbstractSqliteAccessor implements IEventL
 			VALUES (?, ?, ?)
 			ON CONFLICT (projection_name, schema_version, event_id)
 			DO UPDATE SET
-				processing_at = cast(strftime('%f', 'now') * 1000 as INTEGER)
+				processing_at = cast(unixepoch('subsec') * 1000 as INTEGER)
 			WHERE
 				processed_at IS NULL
-				AND processing_at <= cast(strftime('%f', 'now') * 1000 as INTEGER) - ${this.#eventLockTtl}
+				AND processing_at <= cast(unixepoch('subsec') * 1000 as INTEGER) - ${this.#eventLockTtl}
 		`);
 
 		this.#finalizeEventLockQuery = db.prepare(`
 			UPDATE ${this.#eventLockTableName}
 			SET
-				processed_at = (cast(strftime('%f', 'now') * 1000 as INTEGER))
+				processed_at = cast(unixepoch('subsec') * 1000 as INTEGER)
 			WHERE
 				projection_name = ?
 				AND schema_version = ?

--- a/src/sqlite/queries/eventLockTableInit.ts
+++ b/src/sqlite/queries/eventLockTableInit.ts
@@ -3,7 +3,7 @@ export const eventLockTableInit = (eventLockTableName: string) => `
 		projection_name TEXT NOT NULL,
 		schema_version TEXT NOT NULL,
 		event_id BLOB NOT NULL,
-		processing_at INTEGER NOT NULL DEFAULT (cast(strftime('%f', 'now') * 1000 as INTEGER)),
+		processing_at INTEGER NOT NULL DEFAULT (cast(unixepoch('subsec') * 1000 as INTEGER)),
 		processed_at INTEGER,
 		PRIMARY KEY (projection_name, schema_version, event_id)
 	);


### PR DESCRIPTION
`strftime('%f', 'now')` gives a number of seconds limited by the current minute - 0.000 - 59.999. As a result `processed_at` and `processing_at` get a random number between 0 and 59999:

![2025-10-14_11-29-36](https://github.com/user-attachments/assets/f05b72db-492c-43c9-9429-e462f6c6c08d)

Changed to `unixepoch('subsec')`, which is a number of seconds since unix epoch with a fraction. Multiplying by 1000 gives milliseconds.